### PR TITLE
fix: check this.compiler.outputFileSystem.constructor is not undefined (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,26 +12,30 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
 ## UNRELEASED
 
+ * **Bug Fix**
+   * Fix failure with `compiler.outputFileSystem.constructor` being `undefined` ([#447](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/447) by [@kedarv](https://github.com/kedarv) and [@alexander-akait](https://github.com/alexander-akait))
+     * **NOTE:** This fix doesn't have added test coverage so the fix might break in future versions unless test coverage is added later.
+
 ## 4.4.0
 
  * **Improvement**
    * Keep treemap labels visible during zooming animations for better user experience ([#414](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/414) by [@
      stanislawosinski](https://github.com/stanislawosinski))
-     
+
  * **Bug Fix**
    * Don't show an empty tooltip when hovering over the FoamTree attribution group or between top-level groups ([#413](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/413) by [@
      stanislawosinski](https://github.com/stanislawosinski))
- 
+
  * **Internal**
    * Upgrade FoamTree to version 3.5.0, replace vendor dependency with an NPM package ([#412](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/412) by [@
      stanislawosinski](https://github.com/stanislawosinski))
-    
+
 ## 4.3.0
 
  * **Improvement**
    * Replace express with builtin node server, reducing number of dependencies ([#398](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/398) by [@TrySound](https://github.com/TrySound))
    * Move `filesize` to dev dependencies, reducing number of dependencies ([#401](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/401) by [@realityking](https://github.com/realityking))
-   
+
  * **Internal**
    * Replace Travis with GitHub actions ([#402](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/402) by [@valscion](https://github.com/valscion))
 
@@ -56,10 +60,10 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
  * **Improvement**
    * Support for Webpack 5
- 
+
  * **Bug Fix**
    * Prevent crashes when `openAnalyzer` was set to true in environments where there's no program to handle opening. ([#382](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/382) by [@wbobeirne](https://github.com/wbobeirne))
-  
+
  * **Internal**
    * Updated dependencies
    * Added support for multiple Webpack versions in tests
@@ -68,7 +72,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
  * **New Feature**
    * Adds option `reportTitle` to set title in HTML reports; default remains date of report generation ([#354](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/354) by [@eoingroat](https://github.com/eoingroat))
-   
+
  * **Improvement**
     * Added capability to parse bundles that have child assets generated ([#376](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/376) by [@masterkidan](https://github.com/masterkidan) and [#378](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/378) by [@https://github.com/dabbott](https://github.com/https://github.com/dabbott))
 
@@ -95,7 +99,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
  * **Bug Fix**
    * Add leading zero to hour & minute on `<title />` when needed ([#314](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/314) by [@mhxbe](https://github.com/mhxbe))
-   
+
  * **Internal**
    * Update some dependencies to get rid of vulnerability warnings ([#339](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/339))
 
@@ -208,7 +212,7 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
  * **Improvements**
    * Nested folders that contain only one child folder are now visually merged i.e. `folder1 => folder2 => file1` is now shown like `folder1/folder2 => file1` (thanks to [@varun-singh-1](https://github.com/varun-singh-1) for the idea)
-   
+
  * **Internal**
    * Dropped support for Node.js v4
    * Using MobX for state management
@@ -218,10 +222,10 @@ _Note: Gaps between patch versions are faulty, broken or test releases._
 
  * **Improvement**
    * Pretty-format the generated stats.json ([#180](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/180)) [@edmorley](https://github.com/edmorley))
-   
+
  * **Bug Fix**
    * Properly parse Webpack 4 async chunk with `Array.concat` optimization ([#184](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/184), fixes [#183](https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/183))
-  
+
  * **Internal**
    * Refactor bundle parsing logic ([#184](https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/184))
 

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -173,6 +173,9 @@ class BundleAnalyzerPlugin {
   }
 
   getBundleDirFromCompiler() {
+    if (typeof this.compiler.outputFileSystem.constructor === 'undefined') {
+      return this.compiler.outputPath;
+    }
     switch (this.compiler.outputFileSystem.constructor.name) {
       case 'MemoryFileSystem':
         return null;


### PR DESCRIPTION
`this.compiler.outputFileSystem.constructor` can be undefined in webpack 5. This PR cherry picks the fix commit from upstream repository.

See https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/447 for more details.